### PR TITLE
docs: Add deploy to Zeabur button

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ LINE Bot 使用 Google Gemini Pro 跟 Notion DB 來做的名片小幫手
    2.2  按下： [![Deploy to Render](http://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
  來部署到你的 Render 帳號
 
+   2.3. 按下 [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/LS886C) 來免費部署到你的 Zeabur 帳號
+
 3. 除了填寫 App Name 以外，以下的參數必須要填入才能完整運行。
 
    1. **ChannelAccessToken**: 請到 LINE Developers Console issue 一個。


### PR DESCRIPTION
This Pull Request introduces a button to the readme that allows users to deploy the Line bot to the Zeabur platform with a single click.

Zeabur is a new PaaS startup from Taiwan. Unlike Heroku and Render, Zeabur enables the deployment of projects developed in Go through a serverless approach. This allows developers to enjoy a completely free service deployment experience.

After clicking the deployment button, users will be directed to Zeabur’s template introduction page. On the left, there are guided input fields for the various parameters necessary to deploy the bot, helping users intuitively set up their service.

<img width="1523" alt="Screenshot 2024-01-14 at 5 11 18 PM" src="https://github.com/kkdai/linebot-smart-namecard/assets/21105863/378d1627-bbc3-4eb5-805d-b238af0feab7">

<img width="668" alt="Screenshot 2024-01-14 at 5 12 10 PM" src="https://github.com/kkdai/linebot-smart-namecard/assets/21105863/55c6fd0e-5f03-4f64-9f54-84449aea88b1">

<img width="1329" alt="Screenshot 2024-01-14 at 5 15 57 PM" src="https://github.com/kkdai/linebot-smart-namecard/assets/21105863/d4ebb379-1d26-4222-a9d6-2f51182510a8">
