### PR TITLE
refactor: remove UID argument from NotionDB methods

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -75,10 +75,11 @@ func callbackHandler(w http.ResponseWriter, r *http.Request) {
 				nDB := &NotionDB{
 					DatabaseID: os.Getenv("NOTION_DB_PAGEID"),
 					Token:      os.Getenv("NOTION_INTEGRATION_TOKEN"),
+					UID:        uID,
 				}
 
 				// Query the database with the provided uID and text
-				results, err := nDB.QueryDatabaseContains(message.Text, uID)
+				results, err := nDB.QueryDatabaseContains(message.Text)
 				log.Println("Got results:", results)
 
 				// If there's an error or no results, reply with an error message
@@ -155,10 +156,11 @@ func callbackHandler(w http.ResponseWriter, r *http.Request) {
 				nDB := &NotionDB{
 					DatabaseID: os.Getenv("NOTION_DB_PAGEID"),
 					Token:      os.Getenv("NOTION_INTEGRATION_TOKEN"),
+					UID:        uID,
 				}
 
 				// Check email first before adding to database.
-				dbUser, err := nDB.QueryDatabaseByEmail(uID, person.Email)
+				dbUser, err := nDB.QueryDatabaseByEmail(person.Email)
 				if err == nil && len(dbUser) > 0 {
 					log.Println("Already exist in DB", dbUser)
 					if err := replyText(e.ReplyToken, "已經存在於資料庫中，請勿重複輸入"+"\n"+jsonData); err != nil {
@@ -168,7 +170,7 @@ func callbackHandler(w http.ResponseWriter, r *http.Request) {
 				}
 
 				// Add namecard to notion database.
-				err = nDB.AddPageToDatabase(uID, person.Name, person.Title, person.Address, person.Email, person.PhoneNumber)
+				err = nDB.AddPageToDatabase(person.Name, person.Title, person.Address, person.Email, person.PhoneNumber)
 				if err != nil {
 					log.Println("Error adding page to database:", err)
 				}

--- a/notion.go
+++ b/notion.go
@@ -20,13 +20,13 @@ type Person struct {
 type NotionDB struct {
 	DatabaseID string
 	Token      string
+	UID        string
 }
 
 // QueryDatabase 根據提供的屬性和值查詢 Notion 資料庫。
-func (n *NotionDB) QueryDatabase(UId, property, value string) ([]Person, error) {
+func (n *NotionDB) QueryDatabase(property, value string) ([]Person, error) {
 	client := notionapi.NewClient(notionapi.Token(n.Token))
 
-	// Add UId to the filter conditions
 	// 建立查詢過濾條件
 	filter := &notionapi.DatabaseQueryRequest{
 		Filter: notionapi.AndCompoundFilter{
@@ -39,7 +39,7 @@ func (n *NotionDB) QueryDatabase(UId, property, value string) ([]Person, error) 
 			notionapi.PropertyFilter{
 				Property: "UID",
 				RichText: &notionapi.TextFilterCondition{
-					Equals: UId,
+					Equals: n.UID,
 				},
 			},
 		},
@@ -61,10 +61,9 @@ func (n *NotionDB) QueryDatabase(UId, property, value string) ([]Person, error) 
 }
 
 // QueryContainsDatabase 根據提供的屬性和值查詢 Notion 資料庫。
-func (n *NotionDB) QueryContainsDatabase(UId, property, value string) ([]Person, error) {
+func (n *NotionDB) QueryContainsDatabase(property, value string) ([]Person, error) {
 	client := notionapi.NewClient(notionapi.Token(n.Token))
 
-	// Add UId to the filter conditions
 	// 建立查詢過濾條件
 	filter := &notionapi.DatabaseQueryRequest{
 		Filter: notionapi.AndCompoundFilter{
@@ -77,7 +76,7 @@ func (n *NotionDB) QueryContainsDatabase(UId, property, value string) ([]Person,
 			notionapi.PropertyFilter{
 				Property: "UID",
 				RichText: &notionapi.TextFilterCondition{
-					Equals: UId,
+					Equals: n.UID,
 				},
 			},
 		},
@@ -98,13 +97,13 @@ func (n *NotionDB) QueryContainsDatabase(UId, property, value string) ([]Person,
 	return entries, nil
 }
 
-// QueryDatabaseByEmail 根據提供的電子郵件地址和UId查詢 Notion 資料庫。
-func (n *NotionDB) QueryDatabaseByEmail(email, UId string) ([]Person, error) {
-	return n.QueryDatabase(UId, "Email", email)
+// QueryDatabaseByEmail 根據提供的電子郵件地址查詢 Notion 資料庫。
+func (n *NotionDB) QueryDatabaseByEmail(email string) ([]Person, error) {
+	return n.QueryDatabase("Email", email)
 }
 
 // AddPageToDatabase adds a new page with the provided field values to the specified Notion database.
-func (n *NotionDB) AddPageToDatabase(Uid string, name string, title string, address string, email string, phoneNumber string) error {
+func (n *NotionDB) AddPageToDatabase(name string, title string, address string, email string, phoneNumber string) error {
 	client := notionapi.NewClient(notionapi.Token(n.Token))
 
 	// 建立 Properties 物件來設置頁面屬性
@@ -113,7 +112,7 @@ func (n *NotionDB) AddPageToDatabase(Uid string, name string, title string, addr
 			RichText: []notionapi.RichText{
 				{
 					PlainText: name,
-					Text:      &notionapi.Text{Content: Uid},
+					Text:      &notionapi.Text{Content: n.UID},
 				},
 			},
 		},
@@ -174,7 +173,7 @@ func (n *NotionDB) AddPageToDatabase(Uid string, name string, title string, addr
 		return err
 	}
 
-	log.Println("Page added successfully:", Uid, name, title, address, email, phoneNumber)
+	log.Println("Page added successfully:", n.UID, name, title, address, email, phoneNumber)
 	return nil
 }
 
@@ -200,34 +199,34 @@ func (n *NotionDB) getPropertyValue(page *notionapi.Page, property string) strin
 	return ""
 }
 
-// QueryDatabaseByName 根據提供的名稱和UId查詢 Notion 資料庫。
-func (n *NotionDB) QueryDatabaseByName(name, UId string) ([]Person, error) {
-	return n.QueryDatabase(UId, "Name", name)
+// QueryDatabaseByName 根據提供的名稱查詢 Notion 資料庫。
+func (n *NotionDB) QueryDatabaseByName(name string) ([]Person, error) {
+	return n.QueryDatabase("Name", name)
 }
 
-// QueryDatabaseContainsByName 根據提供的名稱和UId查詢 Notion 資料庫。
-func (n *NotionDB) QueryDatabaseContainsByName(name, UId string) ([]Person, error) {
-	return n.QueryContainsDatabase(UId, "Name", name)
+// QueryDatabaseContainsByName 根據提供的名稱查詢 Notion 資料庫。
+func (n *NotionDB) QueryDatabaseContainsByName(name string) ([]Person, error) {
+	return n.QueryContainsDatabase("Name", name)
 }
 
-// QueryDatabaseContainsByEmail 根據提供的名稱和UId查詢 Notion 資料庫。
-func (n *NotionDB) QueryDatabaseContainsByEmail(name, UId string) ([]Person, error) {
-	return n.QueryContainsDatabase(UId, "Email", name)
+// QueryDatabaseContainsByEmail 根據提供的名稱查詢 Notion 資料庫。
+func (n *NotionDB) QueryDatabaseContainsByEmail(name string) ([]Person, error) {
+	return n.QueryContainsDatabase("Email", name)
 }
 
-// QueryDatabaseContainsByName 根據提供的名稱和UId查詢 Notion 資料庫。
-func (n *NotionDB) QueryDatabaseContainsByTitle(name, UId string) ([]Person, error) {
-	return n.QueryContainsDatabase(UId, "Title", name)
+// QueryDatabaseContainsByName 根據提供的名稱查詢 Notion 資料庫。
+func (n *NotionDB) QueryDatabaseContainsByTitle(name string) ([]Person, error) {
+	return n.QueryContainsDatabase("Title", name)
 }
 
-// QueryDatabaseContains 根據提供的名稱和UId查詢 Notion 資料庫。
-func (n *NotionDB) QueryDatabaseContains(query, UId string) ([]Person, error) {
+// QueryDatabaseContains 根據提供的名稱查詢 Notion 資料庫。
+func (n *NotionDB) QueryDatabaseContains(query string) ([]Person, error) {
 	// 初始化一個空的結果集
 	var combinedResult []Person
 
 	// 進行名稱查詢
-	log.Println("QueryDatabaseContainsByName", query, UId)
-	nameResult, err := n.QueryDatabaseContainsByName(query, UId)
+	log.Println("QueryDatabaseContainsByName", query, n.UID)
+	nameResult, err := n.QueryDatabaseContainsByName(query)
 	log.Println("QueryDatabaseContainsByName", nameResult, err)
 	if err != nil {
 		return nil, err
@@ -235,8 +234,8 @@ func (n *NotionDB) QueryDatabaseContains(query, UId string) ([]Person, error) {
 	combinedResult = append(combinedResult, nameResult...)
 
 	// 進行電子郵件查詢
-	log.Println("QueryDatabaseContainsByEmail", query, UId)
-	emailResult, err := n.QueryDatabaseContainsByEmail(query, UId)
+	log.Println("QueryDatabaseContainsByEmail", query, n.UID)
+	emailResult, err := n.QueryDatabaseContainsByEmail(query)
 	log.Println("QueryDatabaseContainsByEmail", emailResult, err)
 	if err != nil {
 		return nil, err
@@ -244,8 +243,8 @@ func (n *NotionDB) QueryDatabaseContains(query, UId string) ([]Person, error) {
 	combinedResult = append(combinedResult, emailResult...)
 
 	// 進行標題查詢
-	log.Println("QueryDatabaseContainsByTitle", query, UId)
-	titleResult, err := n.QueryDatabaseContainsByTitle(query, UId)
+	log.Println("QueryDatabaseContainsByTitle", query, n.UID)
+	titleResult, err := n.QueryDatabaseContainsByTitle(query)
 	log.Println("QueryDatabaseContainsByTitle", titleResult, err)
 	if err != nil {
 		return nil, err

--- a/notion_test.go
+++ b/notion_test.go
@@ -18,15 +18,16 @@ func TestQueryNotionDB(t *testing.T) {
 	db := &NotionDB{
 		DatabaseID: pageid,
 		Token:      token,
+		UID:        "uid",
 	}
 
-	entries, err := db.QueryDatabaseByName("name", "uid")
+	entries, err := db.QueryDatabaseByName("name")
 	if err != nil {
 		t.Fatal(err)
 	}
 	fmt.Printf("%+v\n", entries)
 
-	entries, err = db.QueryDatabaseByEmail("email@email.com", "uid")
+	entries, err = db.QueryDatabaseByEmail("email@email.com")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,9 +47,10 @@ func TestAddNotionDB(t *testing.T) {
 	db := &NotionDB{
 		DatabaseID: pageid,
 		Token:      token,
+		UID:        "uid",
 	}
 
-	err := db.AddPageToDatabase("uid", "name", "title", "address", "emai@email.com", "phone")
+	err := db.AddPageToDatabase("name", "title", "address", "emai@email.com", "phone")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,15 +68,16 @@ func TestQueryContainNotionDB(t *testing.T) {
 	db := &NotionDB{
 		DatabaseID: pageid,
 		Token:      token,
+		UID:        "uid",
 	}
 
-	entries, err := db.QueryDatabaseContainsByName("name", "uid")
+	entries, err := db.QueryDatabaseContainsByName("name")
 	if err != nil {
 		t.Fatal(err)
 	}
 	fmt.Printf("%+v\n", entries)
 
-	entries, err = db.QueryDatabaseContainsByEmail("email", "uid")
+	entries, err = db.QueryDatabaseContainsByEmail("email")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +85,7 @@ func TestQueryContainNotionDB(t *testing.T) {
 	fmt.Printf("%+v\n", entries)
 
 	//test contains all columns (name, title, email)
-	entries, err = db.QueryDatabaseContains("keyword", "uid")
+	entries, err = db.QueryDatabaseContains("keyword")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Added `UID` field to the `NotionDB` struct
- Changed the `QueryDatabaseContains` method to not take `UID` as input
- Changed the `QueryDatabaseByEmail` method to not take `UID` as input
- Changed the `AddPageToDatabase` method to not take `UID` as input
- Removed the `UId` argument from the `QueryDatabase` method
- Removed the `UId` argument from the `QueryContainsDatabase` method
- Removed the `UId` argument from the `QueryDatabaseByName` method
- Removed the `UId` argument from the `QueryDatabaseContainsByName` method
- Removed the `UId` argument from the `QueryDatabaseContainsByEmail` method
- Removed the `UId` argument from the `QueryDatabaseContainsByTitle` method
- Removed the `UId` argument from the `QueryDatabaseContains` method