### PR TITLE
refactor: refactor `AddPageToDatabase` function to use `Person` struc…

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -181,7 +181,7 @@ func callbackHandler(w http.ResponseWriter, r *http.Request) {
 				}
 
 				// Add namecard to notion database.
-				err = nDB.AddPageToDatabase(person.Name, person.Title, person.Address, person.Email, person.PhoneNumber)
+				err = nDB.AddPageToDatabase(person)
 				if err != nil {
 					log.Println("Error adding page to database:", err)
 				}

--- a/notion.go
+++ b/notion.go
@@ -15,6 +15,7 @@ type Person struct {
 	Address     string `json:"address"`
 	Email       string `json:"email"`
 	PhoneNumber string `json:"phone_number"`
+	Company     string `json:"company"`
 }
 
 // DatabaseEntry 定義了 Notion 資料庫條目的結構體。
@@ -93,7 +94,7 @@ func (n *NotionDB) QueryDatabaseByEmail(email string) ([]Person, error) {
 }
 
 // AddPageToDatabase adds a new page with the provided field values to the specified Notion database.
-func (n *NotionDB) AddPageToDatabase(name string, title string, address string, email string, phoneNumber string) error {
+func (n *NotionDB) AddPageToDatabase(person Person) error {
 	client := notionapi.NewClient(notionapi.Token(n.Token))
 
 	// 建立 Properties 物件來設置頁面屬性
@@ -101,7 +102,7 @@ func (n *NotionDB) AddPageToDatabase(name string, title string, address string, 
 		"UID": notionapi.TitleProperty{
 			Title: []notionapi.RichText{
 				{
-					PlainText: name,
+					PlainText: n.UID,
 					Text:      &notionapi.Text{Content: n.UID},
 				},
 			},
@@ -109,40 +110,48 @@ func (n *NotionDB) AddPageToDatabase(name string, title string, address string, 
 		"Name": notionapi.RichTextProperty{
 			RichText: []notionapi.RichText{
 				{
-					PlainText: name,
-					Text:      &notionapi.Text{Content: name},
+					PlainText: person.Name,
+					Text:      &notionapi.Text{Content: person.Name},
 				},
 			},
 		},
 		"Title": notionapi.RichTextProperty{
 			RichText: []notionapi.RichText{
 				{
-					PlainText: name,
-					Text:      &notionapi.Text{Content: title},
+					PlainText: person.Title,
+					Text:      &notionapi.Text{Content: person.Title},
 				},
 			},
 		},
 		"Address": notionapi.RichTextProperty{
 			RichText: []notionapi.RichText{
 				{
-					PlainText: name,
-					Text:      &notionapi.Text{Content: address},
+					PlainText: person.Address,
+					Text:      &notionapi.Text{Content: person.Address},
 				},
 			},
 		},
 		"Email": notionapi.RichTextProperty{
 			RichText: []notionapi.RichText{
 				{
-					PlainText: name,
-					Text:      &notionapi.Text{Content: email},
+					PlainText: person.Email,
+					Text:      &notionapi.Text{Content: person.Email},
 				},
 			},
 		},
 		"Phone Number": notionapi.RichTextProperty{
 			RichText: []notionapi.RichText{
 				{
-					PlainText: name,
-					Text:      &notionapi.Text{Content: phoneNumber},
+					PlainText: person.PhoneNumber,
+					Text:      &notionapi.Text{Content: person.PhoneNumber},
+				},
+			},
+		},
+		"Compyny": notionapi.RichTextProperty{
+			RichText: []notionapi.RichText{
+				{
+					PlainText: person.Company,
+					Text:      &notionapi.Text{Content: person.Company},
 				},
 			},
 		},
@@ -163,7 +172,7 @@ func (n *NotionDB) AddPageToDatabase(name string, title string, address string, 
 		return err
 	}
 
-	log.Println("Page added successfully:", n.UID, name, title, address, email, phoneNumber)
+	log.Println("Page added successfully:", n.UID, person)
 	return nil
 }
 
@@ -176,6 +185,7 @@ func (n *NotionDB) createEntryFromPage(page *notionapi.Page) Person {
 	entry.Address = n.getPropertyValue(page, "Address")
 	entry.Email = n.getPropertyValue(page, "Email")
 	entry.PhoneNumber = n.getPropertyValue(page, "Phone Number")
+	entry.Company = n.getPropertyValue(page, "Company")
 
 	return entry
 }

--- a/notion_test.go
+++ b/notion_test.go
@@ -50,7 +50,7 @@ func TestAddNotionDB(t *testing.T) {
 		UID:        "uid",
 	}
 
-	err := db.AddPageToDatabase("name", "title", "address", "emai@email.com", "phone")
+	err := db.AddPageToDatabase(Person{Name: "test", Title: "test", Address: "test", Email: "test", PhoneNumber: "test", Company: "test"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,4 +91,5 @@ func TestQueryContainNotionDB(t *testing.T) {
 	}
 
 	fmt.Printf("%+v\n", entries)
+
 }


### PR DESCRIPTION
…t instead of individual field parameters

- Modify the `AddPageToDatabase` function to accept a `Person` struct parameter
- Remove the individual field parameters in the `AddPageToDatabase` function and use the `Person` struct instead
- Update the properties passed to the `AddPageToDatabase` function with the corresponding fields from the `Person` struct
- Add the `Company` field to the `Person` struct
- Retrieve the `Company` value from the page in the `createEntryFromPage` function
- Remove the logging of individual field values and log the `Person` struct instead
- Update the test case in `TestAddNotionDB` to pass a `Person` struct as a parameter to `AddPageToDatabase`
- Add an empty line in `TestAddNotionDB`